### PR TITLE
Checkpoint compression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.example</groupId>
     <artifactId>dj-pcfg</artifactId>
-    <version>0.3.15</version>
+    <version>0.4.0</version>
 
     <properties>
 	    <maven.compiler.source>23</maven.compiler.source>
@@ -96,7 +96,6 @@
             <groupId>org.xerial.snappy</groupId>
             <artifactId>snappy-java</artifactId>
             <version>${snappy.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/java/nl/nfi/djpcfg/common/stream/BitInputStream.java
+++ b/src/main/java/nl/nfi/djpcfg/common/stream/BitInputStream.java
@@ -1,0 +1,46 @@
+package nl.nfi.djpcfg.common.stream;
+
+import java.io.ByteArrayInputStream;
+import java.io.Closeable;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+
+public final class BitInputStream implements Closeable {
+
+    private final InputStream input;
+
+    private int bitBuffer;
+    private int restCount;
+
+    private BitInputStream(final InputStream input) {
+        this.input = input;
+    }
+
+    public static BitInputStream forInput(final byte[] input) {
+        return forInput(new ByteArrayInputStream(input));
+    }
+
+    public static BitInputStream forInput(final InputStream input) {
+        return new BitInputStream(input);
+    }
+
+    // returns the next bit in the stream, or throws EOF when none available
+    public int read() throws IOException {
+        if (restCount == 0) {
+            final int next = input.read();
+            if (next == -1) {
+                throw new EOFException();
+            }
+            bitBuffer = next;
+            restCount = 8;
+        }
+        restCount--;
+        return (bitBuffer >>> restCount) & 1;
+    }
+
+    @Override
+    public void close() throws IOException {
+        input.close();
+    }
+}

--- a/src/main/java/nl/nfi/djpcfg/common/stream/BitOutputStream.java
+++ b/src/main/java/nl/nfi/djpcfg/common/stream/BitOutputStream.java
@@ -1,0 +1,67 @@
+package nl.nfi.djpcfg.common.stream;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import static java.lang.Math.min;
+
+public final class BitOutputStream implements Closeable {
+
+    private final OutputStream output;
+
+    private int bitBuffer;
+    private int usedCount;
+
+    private BitOutputStream(final OutputStream output) {
+        this.output = output;
+    }
+
+    public static BitOutputStream forOutput(final OutputStream output) {
+        return new BitOutputStream(output);
+    }
+
+    public void write(final int bits, final int count) throws IOException {
+        int remaining = count;
+        while (remaining > 0) {
+            final int toWrite = min(8 - usedCount, remaining);
+            bitBuffer <<= toWrite;
+            bitBuffer |= ((bits >>> (remaining - toWrite)) & ((1 << toWrite) - 1));
+            usedCount += toWrite;
+            remaining -= toWrite;
+
+            if (usedCount == 8) {
+                flushBits();
+            }
+        }
+    }
+
+    public void write(final long bits, final int count) throws IOException {
+        int remaining = count;
+        while (remaining > 0) {
+            final int toWrite = min(8 - usedCount, remaining);
+            bitBuffer <<= toWrite;
+            bitBuffer |= (int) ((bits >>> (remaining - toWrite)) & ((1 << toWrite) - 1));
+            usedCount += toWrite;
+            remaining -= toWrite;
+
+            if (usedCount == 8) {
+                flushBits();
+            }
+        }
+    }
+
+    private void flushBits() throws IOException {
+        if (usedCount > 0) {
+            output.write(bitBuffer << (8 - usedCount));
+            bitBuffer = 0;
+            usedCount = 0;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        flushBits();
+        output.close();
+    }
+}

--- a/src/main/java/nl/nfi/djpcfg/serialize/Config.java
+++ b/src/main/java/nl/nfi/djpcfg/serialize/Config.java
@@ -1,6 +1,0 @@
-package nl.nfi.djpcfg.serialize;
-
-public final class Config {
-
-    public static final String SERIALIZED_FORMAT_VERSION = "0.0.7";
-}

--- a/src/main/java/nl/nfi/djpcfg/serialize/PcfgCodec.java
+++ b/src/main/java/nl/nfi/djpcfg/serialize/PcfgCodec.java
@@ -1,9 +1,7 @@
 package nl.nfi.djpcfg.serialize;
 
 import nl.nfi.djpcfg.guess.pcfg.Pcfg;
-import nl.nfi.djpcfg.guess.pcfg.RuleInfo;
-import nl.nfi.djpcfg.guess.pcfg.grammar.BaseStructure;
-import nl.nfi.djpcfg.guess.pcfg.grammar.Grammar;
+import nl.nfi.djpcfg.serialize.common.JreTypeCodec;
 
 import java.io.BufferedInputStream;
 import java.io.Closeable;
@@ -11,12 +9,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.charset.Charset;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
 
 import static nl.nfi.djpcfg.serialize.PcfgCodec.Decoder;
 import static nl.nfi.djpcfg.serialize.PcfgCodec.Encoder;
@@ -47,22 +40,9 @@ public abstract sealed class PcfgCodec implements Closeable permits Encoder, Dec
 
         public void write(final Pcfg pcfg) throws IOException {
             encoder.writeString(MAGIC);
-            encoder.writeString(Config.SERIALIZED_FORMAT_VERSION);
+            encoder.writeString(nl.nfi.djpcfg.serialize.v0_0_7.PcfgCodec.VERSION);
 
-            final RuleInfo ruleInfo = pcfg.ruleInfo();
-            encoder.writeString(ruleInfo.uuid().toString());
-            // TODO: change to path of serialized model?
-            encoder.writeString(ruleInfo.basePath().toString());
-            encoder.writeString(ruleInfo.version());
-            encoder.writeString(ruleInfo.encoding().toString());
-
-            final Grammar grammar = pcfg.grammar();
-            GrammarCodec.encodeUsing(encoder).write(grammar);
-
-            encoder.writeList(pcfg.baseStructures(), baseStructure -> {
-                encoder.writeDouble(baseStructure.probability());
-                encoder.writeList(baseStructure.variables(), encoder::writeString);
-            });
+            nl.nfi.djpcfg.serialize.v0_0_7.PcfgCodec.encodeUsing(encoder).write(pcfg);
         }
 
         @Override
@@ -86,30 +66,11 @@ public abstract sealed class PcfgCodec implements Closeable permits Encoder, Dec
             }
 
             final String version = decoder.readString();
-            if (!version.equals(Config.SERIALIZED_FORMAT_VERSION)) {
+            if (!version.equals(nl.nfi.djpcfg.serialize.v0_0_7.PcfgCodec.VERSION)) {
                 throw new UnsupportedOperationException(version);
             }
 
-            final RuleInfo ruleInfo = new RuleInfo(
-                    UUID.fromString(decoder.readString()),
-                    Paths.get(decoder.readString()),
-                    decoder.readString(),
-                    Charset.forName(decoder.readString())
-            );
-            final Grammar grammar = GrammarCodec.decodeUsing(decoder).read();
-
-            final int baseStructureCount = decoder.readVarInt();
-            final List<BaseStructure> baseStructures = new ArrayList<>(baseStructureCount);
-            for (long x = 0; x < baseStructureCount; x++) {
-                final double probability = decoder.readDouble();
-                final int replacementCount = decoder.readVarInt();
-                final List<String> replacements = new ArrayList<>(replacementCount);
-                for (long y = 0; y < replacementCount; y++) {
-                    replacements.add(decoder.readString());
-                }
-                baseStructures.add(new BaseStructure(probability, replacements));
-            }
-            return Pcfg.create(ruleInfo, grammar, baseStructures);
+            return nl.nfi.djpcfg.serialize.v0_0_7.PcfgCodec.decodeUsing(decoder).read();
         }
 
         @Override

--- a/src/main/java/nl/nfi/djpcfg/serialize/common/DelegateReader.java
+++ b/src/main/java/nl/nfi/djpcfg/serialize/common/DelegateReader.java
@@ -1,4 +1,4 @@
-package nl.nfi.djpcfg.serialize;
+package nl.nfi.djpcfg.serialize.common;
 
 import java.io.IOException;
 

--- a/src/main/java/nl/nfi/djpcfg/serialize/common/DelegateWriter.java
+++ b/src/main/java/nl/nfi/djpcfg/serialize/common/DelegateWriter.java
@@ -1,4 +1,4 @@
-package nl.nfi.djpcfg.serialize;
+package nl.nfi.djpcfg.serialize.common;
 
 import java.io.IOException;
 

--- a/src/main/java/nl/nfi/djpcfg/serialize/compression/Code.java
+++ b/src/main/java/nl/nfi/djpcfg/serialize/compression/Code.java
@@ -1,0 +1,15 @@
+package nl.nfi.djpcfg.serialize.compression;
+
+public record Code(int bits, int bitcount) {
+
+    public Code {
+        if (bitcount > 32) {
+            throw new IllegalArgumentException("code with more than 32 bits not supported: " + bitcount);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%32s", Integer.toBinaryString(bits)).replaceAll(" ", "0").substring(32 - bitcount, 32) + "(" + bits + ")";
+    }
+}

--- a/src/main/java/nl/nfi/djpcfg/serialize/compression/CodeTable.java
+++ b/src/main/java/nl/nfi/djpcfg/serialize/compression/CodeTable.java
@@ -1,0 +1,54 @@
+package nl.nfi.djpcfg.serialize.compression;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.SequencedMap;
+
+import static java.util.Comparator.comparing;
+import static java.util.Map.Entry.comparingByKey;
+import static java.util.Map.Entry.comparingByValue;
+
+public final class CodeTable {
+
+    public static SequencedMap<Integer, Code> createCodeTable(final Node root) {
+        final SequencedMap<Integer, Code> codeTable = new LinkedHashMap<>();
+        fillCodeTableRecursively(root, 0, 0, codeTable);
+        return codeTable;
+    }
+
+    private static void fillCodeTableRecursively(final Node node, final int bits, final int count, final Map<Integer, Code> codeTable) {
+        if (node.isLeaf()) {
+            codeTable.put(node.value(), new Code(bits, count));
+        } else {
+            fillCodeTableRecursively(node.l(), bits << 1 | 0, count + 1, codeTable);
+            fillCodeTableRecursively(node.r(), bits << 1 | 1, count + 1, codeTable);
+        }
+    }
+
+    public static SequencedMap<Integer, Code> canonicalize(final SequencedMap<Integer, Code> codeTable) {
+        final List<Entry<Integer, Code>> reordered = codeTable.entrySet().stream()
+                .sorted(comparingByKey())
+                .sorted(comparingByValue(comparing(Code::bitcount)))
+                .toList();
+
+        final SequencedMap<Integer, Code> canonicalized = new LinkedHashMap<>();
+
+        int prevBits = 0;
+        int prevBitcount = 0;
+
+        for (final Entry<Integer, Code> entry : reordered) {
+            final int curBitcount = entry.getValue().bitcount();
+            if (curBitcount > prevBitcount) {
+                prevBits <<= curBitcount - prevBitcount;
+            }
+            canonicalized.put(entry.getKey(), new Code(prevBits, curBitcount));
+
+            prevBits++;
+            prevBitcount = curBitcount;
+        }
+
+        return canonicalized;
+    }
+}

--- a/src/main/java/nl/nfi/djpcfg/serialize/compression/Node.java
+++ b/src/main/java/nl/nfi/djpcfg/serialize/compression/Node.java
@@ -1,0 +1,41 @@
+package nl.nfi.djpcfg.serialize.compression;
+
+import static java.lang.Long.max;
+
+public record Node(int value, long count, Node l, Node r) {
+
+    public static Node internal(final Node l, final Node r) {
+        return new Node(-1, l.count + r.count, l, r);
+    }
+
+    public static Node leaf(final int value, final long count) {
+        if (value < 0) {
+            throw new IllegalArgumentException("value must be >= 0: " + value);
+        }
+        return new Node(value, count, null, null);
+    }
+
+    public boolean isInternal() {
+        return value < 0;
+    }
+
+    public boolean isLeaf() {
+        return value >= 0;
+    }
+
+    public long size() {
+        // implies r is null
+        if (l == null) {
+            return 1;
+        }
+        return 1 + l.size() + r.size();
+    }
+
+    public long depth() {
+        // implies r is null
+        if (l == null) {
+            return 1;
+        }
+        return 1 + max(l.depth(), r.depth());
+    }
+}

--- a/src/main/java/nl/nfi/djpcfg/serialize/v0_0_7/CacheIndexCodec.java
+++ b/src/main/java/nl/nfi/djpcfg/serialize/v0_0_7/CacheIndexCodec.java
@@ -1,0 +1,91 @@
+package nl.nfi.djpcfg.serialize.v0_0_7;
+
+import nl.nfi.djpcfg.guess.cache.CacheIndex;
+import nl.nfi.djpcfg.guess.cache.LRUEntry;
+import nl.nfi.djpcfg.serialize.common.JreTypeCodec;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static nl.nfi.djpcfg.serialize.v0_0_7.CacheIndexCodec.Decoder;
+import static nl.nfi.djpcfg.serialize.v0_0_7.CacheIndexCodec.Encoder;
+
+public abstract sealed class CacheIndexCodec implements Closeable permits Encoder, Decoder {
+
+    public static final String VERSION = "0.0.7";
+
+    public static Encoder encodeUsing(final JreTypeCodec.Encoder encoder) {
+        return new Encoder(encoder);
+    }
+
+    public static Decoder decodeUsing(final JreTypeCodec.Decoder decoder) {
+        return new Decoder(decoder);
+    }
+
+    public static final class Encoder extends CacheIndexCodec {
+
+        private final JreTypeCodec.Encoder encoder;
+
+        private Encoder(final JreTypeCodec.Encoder encoder) {
+            this.encoder = encoder;
+        }
+
+        public void write(final CacheIndex index) throws IOException {
+            encoder.writeLong(index.nextSeqNum());
+
+            encoder.writeMap(index.index(),
+                    uuid -> encoder.writeString(uuid.toString()),
+                    positions -> encoder.writeList(new ArrayList<>(positions), encoder::writeLong)
+            );
+
+            encoder.writeList(index.lru(), entry -> {
+                encoder.writeString(entry.uuid().toString());
+                encoder.writeLong(entry.keyspacePosition());
+                encoder.writeLong(entry.sequenceNumber());
+            });
+        }
+
+        @Override
+        public void close() throws IOException {
+            encoder.close();
+        }
+    }
+
+    public static final class Decoder extends CacheIndexCodec {
+
+        private final JreTypeCodec.Decoder decoder;
+
+        private Decoder(final JreTypeCodec.Decoder decoder) {
+            this.decoder = decoder;
+        }
+
+        public CacheIndex read() throws IOException {
+            final long nextSeqNum = decoder.readLong();
+
+            final Map<UUID, Set<Long>> idx = decoder.readMap(
+                    () -> UUID.fromString(decoder.readString()),
+                    () -> new HashSet<>(decoder.readList(decoder::readLong))
+            );
+
+            final List<LRUEntry> lru = decoder.readList(
+                    () -> new LRUEntry(
+                            UUID.fromString(decoder.readString()),
+                            decoder.readLong(),
+                            decoder.readLong()
+                    )
+            );
+            return CacheIndex.init(nextSeqNum, idx, lru);
+        }
+
+        @Override
+        public void close() throws IOException {
+            decoder.close();
+        }
+    }
+}

--- a/src/main/java/nl/nfi/djpcfg/serialize/v0_0_7/CheckpointCodec.java
+++ b/src/main/java/nl/nfi/djpcfg/serialize/v0_0_7/CheckpointCodec.java
@@ -1,0 +1,108 @@
+package nl.nfi.djpcfg.serialize.v0_0_7;
+
+import nl.nfi.djpcfg.guess.cache.Checkpoint;
+import nl.nfi.djpcfg.guess.pcfg.HeapLimitingPTQueue;
+import nl.nfi.djpcfg.guess.pcfg.ParseTree;
+import nl.nfi.djpcfg.guess.pcfg.Pcfg;
+import nl.nfi.djpcfg.guess.pcfg.ReplacementSet;
+import nl.nfi.djpcfg.guess.pcfg.grammar.BaseStructure;
+import nl.nfi.djpcfg.serialize.common.JreTypeCodec;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+
+import static java.util.Comparator.comparing;
+import static nl.nfi.djpcfg.serialize.v0_0_7.CheckpointCodec.Decoder;
+import static nl.nfi.djpcfg.serialize.v0_0_7.CheckpointCodec.Encoder;
+
+public abstract sealed class CheckpointCodec implements Closeable permits Encoder, Decoder {
+
+    public static final String VERSION = "0.0.7";
+
+    public static Encoder encodeUsing(final JreTypeCodec.Encoder encoder) {
+        return new Encoder(encoder);
+    }
+
+    public static Decoder decodeUsing(final JreTypeCodec.Decoder decoder) {
+        return new Decoder(decoder);
+    }
+
+    public static final class Encoder extends CheckpointCodec {
+
+        private final JreTypeCodec.Encoder encoder;
+
+        private Encoder(final JreTypeCodec.Encoder encoder) {
+            this.encoder = encoder;
+        }
+
+        public void writeCheckpointUsingBaseRefs(final Pcfg pcfg, final Checkpoint state) throws IOException {
+            final Map<List<String>, Integer> lookup = new HashMap<>();
+            final List<BaseStructure> baseStructures = pcfg.baseStructures();
+            for (int i = 0; i < baseStructures.size(); i++) {
+                final BaseStructure baseStructure = baseStructures.get(i);
+                lookup.put(baseStructure.variables(), i);
+            }
+
+            encoder.writeCollection(state.queue(), parseTree -> writeParseTreeUsingBaseRefs(lookup, parseTree));
+            writeParseTreeUsingBaseRefs(lookup, state.next());
+            encoder.writeLong(state.keyspacePosition());
+        }
+
+        private void writeParseTreeUsingBaseRefs(final Map<List<String>, Integer> lookup, final ParseTree parseTree) throws IOException {
+            encoder.writeVarInt(lookup.get(parseTree.replacementSet().variables()));
+            encoder.writeDouble(parseTree.probability());
+            encoder.writeVarIntArray(parseTree.replacementSet().indices());
+        }
+
+        @Override
+        public void close() throws IOException {
+            encoder.close();
+        }
+    }
+
+    public static final class Decoder extends CheckpointCodec {
+
+        private final JreTypeCodec.Decoder decoder;
+
+        private Decoder(final JreTypeCodec.Decoder decoder) {
+            this.decoder = decoder;
+        }
+
+        public Checkpoint readCheckpointUsingBaseRefs(final Pcfg pcfg) throws IOException {
+            final Map<Integer, BaseStructure> lookup = new HashMap<>();
+            final List<BaseStructure> baseStructures = pcfg.baseStructures();
+            for (int i = 0; i < baseStructures.size(); i++) {
+                final BaseStructure baseStructure = baseStructures.get(i);
+                lookup.put(i, baseStructure);
+            }
+
+            final PriorityQueue<ParseTree> queue = decoder.readQueue(() -> readParseTreeUsingBaseRefs(lookup), size ->
+                    new HeapLimitingPTQueue(size, comparing(ParseTree::probability).reversed())
+            );
+            final ParseTree next = readParseTreeUsingBaseRefs(lookup);
+            final long pos = decoder.readLong();
+            return new Checkpoint(queue, next, pos);
+        }
+
+        private ParseTree readParseTreeUsingBaseRefs(final Map<Integer, BaseStructure> lookup) throws IOException {
+            final BaseStructure base = lookup.get(decoder.readVarInt());
+            final double probability = decoder.readDouble();
+            final int[] indices = decoder.readVarIntArray();
+
+            return new ParseTree(
+                    base.probability(),
+                    probability,
+                    new ReplacementSet(base.variables(), indices)
+            );
+        }
+
+        @Override
+        public void close() throws IOException {
+            decoder.close();
+        }
+    }
+}

--- a/src/main/java/nl/nfi/djpcfg/serialize/v0_0_7/GrammarCodec.java
+++ b/src/main/java/nl/nfi/djpcfg/serialize/v0_0_7/GrammarCodec.java
@@ -1,26 +1,27 @@
-package nl.nfi.djpcfg.serialize;
+package nl.nfi.djpcfg.serialize.v0_0_7;
 
 import nl.nfi.djpcfg.guess.pcfg.grammar.Grammar;
 import nl.nfi.djpcfg.guess.pcfg.grammar.TerminalGroup;
+import nl.nfi.djpcfg.serialize.common.JreTypeCodec;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static nl.nfi.djpcfg.serialize.GrammarCodec.Decoder;
-import static nl.nfi.djpcfg.serialize.GrammarCodec.Encoder;
+import static nl.nfi.djpcfg.serialize.v0_0_7.GrammarCodec.Decoder;
+import static nl.nfi.djpcfg.serialize.v0_0_7.GrammarCodec.Encoder;
 
 sealed class GrammarCodec permits Encoder, Decoder {
 
-    public static Encoder encodeUsing(final JreTypeCodec.Encoder encoder) {
+    static Encoder encodeUsing(final JreTypeCodec.Encoder encoder) {
         return new Encoder(encoder);
     }
 
-    public static Decoder decodeUsing(final JreTypeCodec.Decoder decoder) {
+    static Decoder decodeUsing(final JreTypeCodec.Decoder decoder) {
         return new Decoder(decoder);
     }
 
-    public static final class Encoder extends GrammarCodec {
+    static final class Encoder extends GrammarCodec {
 
         private final JreTypeCodec.Encoder encoder;
 
@@ -40,7 +41,7 @@ sealed class GrammarCodec permits Encoder, Decoder {
         }
     }
 
-    public static final class Decoder extends GrammarCodec {
+    static final class Decoder extends GrammarCodec {
 
         private final JreTypeCodec.Decoder decoder;
 

--- a/src/main/java/nl/nfi/djpcfg/serialize/v0_0_7/PcfgCodec.java
+++ b/src/main/java/nl/nfi/djpcfg/serialize/v0_0_7/PcfgCodec.java
@@ -1,0 +1,99 @@
+package nl.nfi.djpcfg.serialize.v0_0_7;
+
+import nl.nfi.djpcfg.guess.pcfg.Pcfg;
+import nl.nfi.djpcfg.guess.pcfg.RuleInfo;
+import nl.nfi.djpcfg.guess.pcfg.grammar.BaseStructure;
+import nl.nfi.djpcfg.guess.pcfg.grammar.Grammar;
+import nl.nfi.djpcfg.serialize.common.JreTypeCodec;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static nl.nfi.djpcfg.serialize.v0_0_7.PcfgCodec.Decoder;
+import static nl.nfi.djpcfg.serialize.v0_0_7.PcfgCodec.Encoder;
+
+public abstract sealed class PcfgCodec implements Closeable permits Encoder, Decoder {
+
+    public static final String VERSION = "0.0.7";
+
+    public static Encoder encodeUsing(final JreTypeCodec.Encoder encoder) {
+        return new Encoder(encoder);
+    }
+
+    public static Decoder decodeUsing(final JreTypeCodec.Decoder decoder) {
+        return new Decoder(decoder);
+    }
+    
+    public static final class Encoder extends PcfgCodec {
+
+        private final JreTypeCodec.Encoder encoder;
+
+        private Encoder(final JreTypeCodec.Encoder encoder) {
+            this.encoder = encoder;
+        }
+
+        public void write(final Pcfg pcfg) throws IOException {
+            final RuleInfo ruleInfo = pcfg.ruleInfo();
+            encoder.writeString(ruleInfo.uuid().toString());
+            // TODO: change to path of serialized model?
+            encoder.writeString(ruleInfo.basePath().toString());
+            encoder.writeString(ruleInfo.version());
+            encoder.writeString(ruleInfo.encoding().toString());
+
+            final Grammar grammar = pcfg.grammar();
+            GrammarCodec.encodeUsing(encoder).write(grammar);
+
+            encoder.writeList(pcfg.baseStructures(), baseStructure -> {
+                encoder.writeDouble(baseStructure.probability());
+                encoder.writeList(baseStructure.variables(), encoder::writeString);
+            });
+        }
+
+        @Override
+        public void close() throws IOException {
+            encoder.close();
+        }
+    }
+
+    public static final class Decoder extends PcfgCodec {
+
+        private final JreTypeCodec.Decoder decoder;
+
+        private Decoder(final JreTypeCodec.Decoder decoder) {
+            this.decoder = decoder;
+        }
+
+        public Pcfg read() throws IOException {
+            final RuleInfo ruleInfo = new RuleInfo(
+                    UUID.fromString(decoder.readString()),
+                    Paths.get(decoder.readString()),
+                    decoder.readString(),
+                    Charset.forName(decoder.readString())
+            );
+            final Grammar grammar = GrammarCodec.decodeUsing(decoder).read();
+
+            final int baseStructureCount = decoder.readVarInt();
+            final List<BaseStructure> baseStructures = new ArrayList<>(baseStructureCount);
+            for (long x = 0; x < baseStructureCount; x++) {
+                final double probability = decoder.readDouble();
+                final int replacementCount = decoder.readVarInt();
+                final List<String> replacements = new ArrayList<>(replacementCount);
+                for (long y = 0; y < replacementCount; y++) {
+                    replacements.add(decoder.readString());
+                }
+                baseStructures.add(new BaseStructure(probability, replacements));
+            }
+            return Pcfg.create(ruleInfo, grammar, baseStructures);
+        }
+
+        @Override
+        public void close() throws IOException {
+            decoder.close();
+        }
+    }
+}

--- a/src/main/java/nl/nfi/djpcfg/serialize/v0_4_0/CheckpointCodec.java
+++ b/src/main/java/nl/nfi/djpcfg/serialize/v0_4_0/CheckpointCodec.java
@@ -1,0 +1,277 @@
+package nl.nfi.djpcfg.serialize.v0_4_0;
+
+import nl.nfi.djpcfg.common.stream.BitInputStream;
+import nl.nfi.djpcfg.common.stream.BitOutputStream;
+import nl.nfi.djpcfg.guess.cache.Checkpoint;
+import nl.nfi.djpcfg.guess.pcfg.HeapLimitingPTQueue;
+import nl.nfi.djpcfg.guess.pcfg.ParseTree;
+import nl.nfi.djpcfg.guess.pcfg.Pcfg;
+import nl.nfi.djpcfg.guess.pcfg.ReplacementSet;
+import nl.nfi.djpcfg.guess.pcfg.grammar.BaseStructure;
+import nl.nfi.djpcfg.serialize.common.JreTypeCodec;
+import nl.nfi.djpcfg.serialize.compression.Code;
+import nl.nfi.djpcfg.serialize.compression.CodeTable;
+import nl.nfi.djpcfg.serialize.compression.Node;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xerial.snappy.BitShuffle;
+import org.xerial.snappy.Snappy;
+
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.SequencedMap;
+
+import static java.util.Comparator.comparing;
+import static java.util.Comparator.comparingDouble;
+import static java.util.Comparator.comparingLong;
+import static nl.nfi.djpcfg.serialize.v0_4_0.CheckpointCodec.Decoder;
+import static nl.nfi.djpcfg.serialize.v0_4_0.CheckpointCodec.Encoder;
+
+public abstract sealed class CheckpointCodec implements Closeable permits Encoder, Decoder {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CheckpointCodec.class);
+
+    public static final String VERSION = "0.4.0";
+
+    public static Encoder encodeUsing(final JreTypeCodec.Encoder encoder) {
+        return new Encoder(encoder);
+    }
+
+    public static Decoder decodeUsing(final JreTypeCodec.Decoder decoder) {
+        return new Decoder(decoder);
+    }
+    public static final class Encoder extends CheckpointCodec {
+
+        private final JreTypeCodec.Encoder encoder;
+
+        private Encoder(final JreTypeCodec.Encoder encoder) {
+            this.encoder = encoder;
+        }
+
+        public void writeCheckpointUsingBaseRefs(final Pcfg pcfg, final Checkpoint state) throws IOException {
+            final Map<List<String>, Integer> lookup = new HashMap<>();
+            final List<BaseStructure> baseStructures = pcfg.baseStructures();
+            for (int i = 0; i < baseStructures.size(); i++) {
+                final BaseStructure baseStructure = baseStructures.get(i);
+                lookup.put(baseStructure.variables(), i);
+            }
+
+            writeQueueState(state, lookup);
+            writeParseTreeUsingBaseRefs(lookup, state.next());
+            encoder.writeLong(state.keyspacePosition());
+        }
+
+        private void writeQueueState(final Checkpoint state, final Map<List<String>, Integer> lookup) throws IOException {
+            final List<ParseTree> entries = state.queue()
+                    .stream()
+                     // .parallelStream() // TODO: calling this inside gRPC observer makes everything slow, thread contention?
+                    .sorted(comparingDouble(ParseTree::probability))
+                    .toList();
+
+            // write the references to the base structure of each parse tree
+            final int[] references = entries.stream()
+                    .mapToInt(parseTree -> lookup.get(parseTree.replacementSet().variables()))
+                    .toArray();
+
+            encoder.writeBytes(Snappy.compress(BitShuffle.shuffle(references)));
+
+            // write the probability of each parse tree
+            final long[] probabilities = entries.stream()
+                    .mapToLong(parseTree -> Double.doubleToLongBits(parseTree.probability()))
+                    .toArray();
+
+            // before compression, xor neighbours because most bits will be equal, so we get better compression
+            for (int i = probabilities.length - 1; i >= 1; i--) {
+                probabilities[i] ^= probabilities[i - 1];
+            }
+
+            encoder.writeBytes(Snappy.compress(probabilities));
+
+            // create frequency table for each used index referring to a terminal group
+            final Map<Integer, Integer> frequencyTable = new HashMap<>();
+            for (final ParseTree parseTree : entries) {
+                final int[] indices = parseTree.replacementSet().indices();
+                // count occurrences of each index
+                for (final int index : indices) {
+                    frequencyTable.merge(index, 1, Integer::sum);
+                }
+            }
+
+            // queue ordering nodes from least to most encountered
+            final PriorityQueue<Node> queue = new PriorityQueue<>(comparingLong(Node::count));
+            frequencyTable.forEach((key, count) -> {
+                queue.add(Node.leaf(key, count));
+            });
+
+            // keep merging least encountered value nodes until we built the binary tree
+            while (queue.size() > 1) {
+                final Node l = queue.poll();
+                final Node r = queue.poll();
+                queue.add(Node.internal(l, r));
+            }
+
+            // now get the tree and build the code table
+            final Node root = queue.poll();
+            // table is mapping from value to prefix code
+            // we also canonicalize it, so we only have to send the bit lengths
+            final SequencedMap<Integer, Code> codeTable = CodeTable.canonicalize(CodeTable.createCodeTable(root));
+
+            // write the values of the code table
+            final int[] values = codeTable.keySet().stream()
+                    .mapToInt(l -> l)
+                    .toArray();
+
+            encoder.writeBytes(Snappy.compress(BitShuffle.shuffle(values)));
+
+            // write the bit lengths of each code
+            final int[] bitcounts = codeTable.values().stream()
+                    .mapToInt(Code::bitcount)
+                    .toArray();
+
+            encoder.writeBytes(Snappy.compress(BitShuffle.shuffle(bitcounts)));
+
+            // write all the replacement indices data
+            final ByteArrayOutputStream encodedBytes = new ByteArrayOutputStream();
+            try (final BitOutputStream bitstream = BitOutputStream.forOutput(encodedBytes)) {
+                for (final ParseTree parseTree : entries) {
+                    final int[] indices = parseTree.replacementSet().indices();
+                    for (final int index : indices) {
+                        final Code indexCode = codeTable.get(index);
+                        bitstream.write(indexCode.bits(), indexCode.bitcount());
+                    }
+                }
+            }
+
+            encoder.writeBytes(encodedBytes.toByteArray());
+        }
+
+        private void writeParseTreeUsingBaseRefs(final Map<List<String>, Integer> lookup, final ParseTree parseTree) throws IOException {
+            encoder.writeVarInt(lookup.get(parseTree.replacementSet().variables()));
+            encoder.writeDouble(parseTree.probability());
+            encoder.writeVarIntArray(parseTree.replacementSet().indices());
+        }
+
+        @Override
+        public void close() throws IOException {
+            encoder.close();
+        }
+    }
+
+    public static final class Decoder extends CheckpointCodec {
+
+        private final JreTypeCodec.Decoder decoder;
+
+        private Decoder(final JreTypeCodec.Decoder decoder) {
+            this.decoder = decoder;
+        }
+
+        public Checkpoint readCheckpointUsingBaseRefs(final Pcfg pcfg) throws IOException {
+            final Map<Integer, BaseStructure> lookup = new HashMap<>();
+            final List<BaseStructure> baseStructures = pcfg.baseStructures();
+            for (int i = 0; i < baseStructures.size(); i++) {
+                final BaseStructure baseStructure = baseStructures.get(i);
+                lookup.put(i, baseStructure);
+            }
+
+            final PriorityQueue<ParseTree> queue = readQueueState(lookup);
+            final ParseTree next = readParseTreeUsingBaseRefs(lookup);
+            final long pos = decoder.readLong();
+            return new Checkpoint(queue, next, pos);
+        }
+
+        private PriorityQueue<ParseTree> readQueueState(final Map<Integer, BaseStructure> lookup) throws IOException {
+            // i.e. pointers to the base structures of the grammar
+            final int[] references = BitShuffle.unshuffleIntArray(Snappy.uncompress(decoder.readBytes()));
+            final int queueSize = references.length;
+            System.out.println("Queue size: " + queueSize);
+
+            final long[] probabilities = Snappy.uncompressLongArray(decoder.readBytes());
+            for (int i = 1; i < probabilities.length; i++) {
+                probabilities[i] ^= probabilities[i - 1];
+            }
+
+            final int[] values = BitShuffle.unshuffleIntArray(Snappy.uncompress(decoder.readBytes()));
+            final int[] bitcounts = BitShuffle.unshuffleIntArray(Snappy.uncompress(decoder.readBytes()));
+
+            final Map<Code, Integer> codeTable = buildCodeTable(values, bitcounts);
+
+            final byte[] encodedIndices = decoder.readBytes();
+
+            final PriorityQueue<ParseTree> queue = new HeapLimitingPTQueue(queueSize, comparing(ParseTree::probability).reversed());
+            try (final BitInputStream bitstream = BitInputStream.forInput(encodedIndices)) {
+                for (int i = 0; i < queueSize; i++) {
+                    final int reference = references[i];
+                    final double probability = Double.longBitsToDouble(probabilities[i]);
+                    final BaseStructure base = lookup.get(reference);
+                    final int[] indices = new int[base.variables().size()];
+
+                    for (int j = 0; j < indices.length; j++) {
+                        indices[j] = findNextIndex(bitstream, codeTable);
+                    }
+
+                    queue.add(new ParseTree(
+                            base.probability(),
+                            probability,
+                            new ReplacementSet(base.variables(), indices)
+                    ));
+                }
+            }
+            return queue;
+        }
+
+        private static Map<Code, Integer> buildCodeTable(final int[] values, final int[] bitcounts) {
+            final Map<Code, Integer> codeTable = new HashMap<>();
+
+            int prevBits = 0;
+            int prevBitcount = bitcounts[0];
+
+            for (int i = 0; i < bitcounts.length; i++) {
+                final int curBitcount = bitcounts[i];
+                if (curBitcount > prevBitcount) {
+                    prevBits <<= curBitcount - prevBitcount;
+                }
+                codeTable.put(new Code(prevBits, curBitcount), values[i]);
+                prevBits++;
+                prevBitcount = curBitcount;
+            }
+
+            return codeTable;
+        }
+
+        private int findNextIndex(final BitInputStream bitstream, final Map<Code, Integer> codeTable) throws IOException {
+            return findNextIndexRecursively(bitstream, codeTable, 0, 0);
+        }
+
+        private int findNextIndexRecursively(final BitInputStream bitstream, final Map<Code, Integer> codeTable, final int currentCode, final int bitcount) throws IOException {
+            final int nextPossibleCode = currentCode << 1 | bitstream.read();
+            final int curBitCount = bitcount + 1;
+            final Integer possibleIndex = codeTable.get(new Code(nextPossibleCode, curBitCount));
+            if (possibleIndex != null) {
+                return possibleIndex;
+            }
+            return findNextIndexRecursively(bitstream, codeTable, nextPossibleCode, curBitCount);
+        }
+
+        private ParseTree readParseTreeUsingBaseRefs(final Map<Integer, BaseStructure> lookup) throws IOException {
+            final BaseStructure base = lookup.get(decoder.readVarInt());
+            final double probability = decoder.readDouble();
+            final int[] indices = decoder.readVarIntArray();
+
+            return new ParseTree(
+                    base.probability(),
+                    probability,
+                    new ReplacementSet(base.variables(), indices)
+            );
+        }
+
+        @Override
+        public void close() throws IOException {
+            decoder.close();
+        }
+    }
+}

--- a/src/test/java/nl/nfi/djpcfg/Utils.java
+++ b/src/test/java/nl/nfi/djpcfg/Utils.java
@@ -1,7 +1,7 @@
 package nl.nfi.djpcfg;
 
 import nl.nfi.djpcfg.guess.pcfg.PcfgGuesser;
-import nl.nfi.djpcfg.serialize.JreTypeCodec;
+import nl.nfi.djpcfg.serialize.common.JreTypeCodec;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -136,5 +136,12 @@ public final class Utils {
     }
 
     public record ScoredEntry(String password, double score) {
+    }
+
+    public record Tuple<L, R>(L left, R right) {
+
+        public static <L, R> Tuple<L, R> of(L left, R right) {
+            return new Tuple<>(left, right);
+        }
     }
 }

--- a/src/test/java/nl/nfi/djpcfg/common/stream/BitInputStreamTest.java
+++ b/src/test/java/nl/nfi/djpcfg/common/stream/BitInputStreamTest.java
@@ -1,0 +1,101 @@
+package nl.nfi.djpcfg.common.stream;
+
+import nl.nfi.djpcfg.Utils.Tuple;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+class BitInputStreamTest {
+
+    @ParameterizedTest
+    @MethodSource("generateReadTestCases")
+    void read(final byte[] bitstream, final int readCount, final int[] expectedBits) throws IOException {
+        final int[] bits = new int[readCount];
+        try (final BitInputStream input = BitInputStream.forInput(bitstream)) {
+            for (int i = 0; i < readCount; i++) {
+                bits[i] = input.read();
+            }
+        }
+        assertThat(bits).isEqualTo(expectedBits);
+    }
+
+    static Stream<Arguments> generateReadTestCases() {
+        final Map<Tuple<byte[], Integer>, int[]> testCases = new LinkedHashMap<>();
+        // 1
+        testCases.put(Tuple.of(input(), 0), bits());
+        testCases.put(Tuple.of(input(0b10000000), 1), bits(1));
+        testCases.put(Tuple.of(input(0b10000000), 2), bits(1, 0));
+        testCases.put(Tuple.of(input(0b10000000), 8), bits(1, 0, 0, 0, 0, 0, 0, 0));
+        // 5
+        testCases.put(Tuple.of(input(0b10010011, 0b00010010), 0), bits());
+        testCases.put(Tuple.of(input(0b10010011, 0b00010010), 1), bits(1));
+        testCases.put(Tuple.of(input(0b10010011, 0b00010010), 2), bits(1, 0));
+        testCases.put(Tuple.of(input(0b10010011, 0b00010010), 3), bits(1, 0, 0));
+        testCases.put(Tuple.of(input(0b10010011, 0b00010010), 4), bits(1, 0, 0, 1));
+        // 10
+        testCases.put(Tuple.of(input(0b10010011, 0b00010010), 5), bits(1, 0, 0, 1, 0));
+        testCases.put(Tuple.of(input(0b10010011, 0b00010010), 6), bits(1, 0, 0, 1, 0, 0));
+        testCases.put(Tuple.of(input(0b10010011, 0b00010010), 7), bits(1, 0, 0, 1, 0, 0, 1));
+        testCases.put(Tuple.of(input(0b10010011, 0b00010010), 8), bits(1, 0, 0, 1, 0, 0, 1, 1));
+        testCases.put(Tuple.of(input(0b10010011, 0b00010010), 9), bits(1, 0, 0, 1, 0, 0, 1, 1, 0));
+        // 15
+        testCases.put(Tuple.of(input(0b10010011, 0b00010010), 10), bits(1, 0, 0, 1, 0, 0, 1, 1, 0, 0));
+        testCases.put(Tuple.of(input(0b10010011, 0b00010010), 11), bits(1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0));
+        testCases.put(Tuple.of(input(0b10010011, 0b00010010), 12), bits(1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1));
+        testCases.put(Tuple.of(input(0b10010011, 0b00010010), 13), bits(1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0));
+        testCases.put(Tuple.of(input(0b10010011, 0b00010010), 14), bits(1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0));
+        // 20
+        testCases.put(Tuple.of(input(0b10010011, 0b00010010), 15), bits(1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1));
+        testCases.put(Tuple.of(input(0b10010011, 0b00010010), 16), bits(1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0));
+        testCases.put(Tuple.of(input(0b10010011, 0b00010010, 0b10000000), 17), bits(1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1));
+        testCases.put(Tuple.of(input(0b10010011, 0b00010010, 0b10000000), 18), bits(1, 0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0));
+
+        return testCases.entrySet().stream()
+            .map(entry -> {
+                final Tuple<byte[], Integer> input = entry.getKey();
+                final byte[] bitStream = input.left();
+                final int readCount = input.right();
+                final int[] expectedBits = entry.getValue();
+
+                final String[] bitStreamDisplay = new String[bitStream.length];
+                for (int i = 0; i < bitStream.length; i++) {
+                    bitStreamDisplay[i] = byteToBinaryString(bitStream[i]);
+                }
+                final String[] expectedBitsDisplay = new String[expectedBits.length];
+                for (int i = 0; i < expectedBits.length; i++) {
+                    expectedBitsDisplay[i] = expectedBits[i] + "";
+                }
+
+                return argumentSet(
+                    String.join(" ", bitStreamDisplay) + " read(" + readCount + ") => " + String.join(" ", expectedBitsDisplay),
+                    bitStream,
+                    readCount,
+                    expectedBits
+                );
+            });
+    }
+
+    private static byte[] input(final int... bytes) {
+        final byte[] converted = new byte[bytes.length];
+        for (int i = 0; i < bytes.length; i++) {
+            converted[i] = (byte) bytes[i];
+        }
+        return converted;
+    }
+
+    private static int[] bits(final int... bits) {
+        return bits;
+    }
+
+    public static String byteToBinaryString(final int uByte) {
+        return String.format("%8s", Integer.toBinaryString(uByte & 0xff)).replaceAll(" ", "0");
+    }
+}

--- a/src/test/java/nl/nfi/djpcfg/common/stream/BitOutputStreamTest.java
+++ b/src/test/java/nl/nfi/djpcfg/common/stream/BitOutputStreamTest.java
@@ -1,0 +1,186 @@
+package nl.nfi.djpcfg.common.stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
+
+class BitOutputStreamTest {
+
+    @ParameterizedTest
+    @MethodSource("generateWriteIntTestCases")
+    void writeIntBits(final int[] writes, final byte[] expectedBytes) throws IOException {
+        final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (final BitOutputStream output = BitOutputStream.forOutput(bytes)) {
+            for (int i = 0; i < writes.length / 2; i++) {
+                output.write(writes[i * 2 + 0], writes[i * 2 + 1]);
+            }
+        }
+        assertThat(bytes.toByteArray()).isEqualTo(expectedBytes);
+    }
+
+    static Stream<Arguments> generateWriteIntTestCases() {
+        final Map<int[], byte[]> testCases = new LinkedHashMap<>();
+        // 1
+        testCases.put(writes(), expected());
+        testCases.put(writes(0b00000000, 0), expected());
+        testCases.put(writes(0b11111111, 0), expected());
+        testCases.put(writes(0b00000000, 1), expected(0b00000000));
+        // 5
+        testCases.put(writes(0b00000001, 1), expected(0b10000000));
+        testCases.put(writes(0b00000011, 4), expected(0b00110000));
+        testCases.put(writes(0b10000011, 8), expected(0b10000011));
+        testCases.put(writes(0b00000001, 1, 0b00000010, 3), expected(0b10100000));
+        testCases.put(writes(0b00000001, 1, 0b00000010, 3, 0b00000011, 4), expected(0b10100011));
+        // 10
+        testCases.put(writes(0b10101010, 8, 0b00000001, 1), expected(0b10101010, 0b10000000));
+        testCases.put(writes(0b11110000, 8, 0b00001111, 8), expected(0b11110000, 0b00001111));
+        testCases.put(writes(0b11110000, 8, 0b00001111, 8, 0b00001111, 4), expected(0b11110000, 0b00001111, 0b11110000));
+
+        testCases.put(writes(0b00000001, 1), expected(0b10000000));
+        testCases.put(writes(0b00000001, 1, 0b00000001, 1), expected(0b11000000));
+        // 15
+        testCases.put(writes(0b00000001, 1, 0b00000001, 1, 0b00000001, 1), expected(0b11100000));
+        testCases.put(writes(0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1), expected(0b11110000));
+        testCases.put(writes(0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1), expected(0b11111000));
+        testCases.put(writes(0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1), expected(0b11111100));
+        testCases.put(writes(0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1), expected(0b11111110));
+        // 20
+        testCases.put(writes(0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1), expected(0b11111111));
+        testCases.put(writes(0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1), expected(0b11111111, 0b10000000));
+        testCases.put(writes(0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1), expected(0b11111111, 0b11000000));
+
+//        testCases.put(writes(0x12345678, 9), expected(0x04, 0x68, 0xac, 0xf0));
+//        testCases.put(writes(0x12345678, 15), expected(0x04, 0x68, 0xac, 0xf0));
+//        testCases.put(writes(0x12345678, 16), expected(0x04, 0x68, 0xac, 0xf0));
+//        testCases.put(writes(0x12345678, 17), expected(0x04, 0x68, 0xac, 0xf0));
+//        testCases.put(writes(0x12345678, 23), expected(0x04, 0x68, 0xac, 0xf0));
+//        testCases.put(writes(0x12345678, 24), expected(0x04, 0x68, 0xac, 0xf0));
+        testCases.put(writes(0x12345678, 25), expected(0x1a, 0x2b, 0x3c, 0x00));
+        testCases.put(writes(0x12345678, 31), expected(0x24, 0x68, 0xac, 0xf0));
+        testCases.put(writes(0x12345678, 32), expected(0x12, 0x34, 0x56, 0x78));
+
+        return testCases.entrySet().stream()
+            .map(entry -> {
+                final int[] writes = entry.getKey();
+                final byte[] expected = entry.getValue();
+
+                final String[] writesDisplay = new String[writes.length / 2];
+                for (int i = 0; i < writes.length / 2; i++) {
+                    writesDisplay[i] = "<" + longToBinaryString(writes[i * 2 + 0] & 0xffffffffL).substring(64 - writes[i * 2 + 1], 64) + ">";
+                }
+                final String[] expectedDisplay = new String[expected.length];
+                for (int i = 0; i < expected.length; i++) {
+                    expectedDisplay[i] = byteToBinaryString(expected[i] & 0xff);
+                }
+
+                return argumentSet(
+                    String.join(" ", writesDisplay) + " => " + String.join(" ", expectedDisplay),
+                    writes,
+                    expected
+                );
+            });
+    }
+
+    @ParameterizedTest
+    @MethodSource("generateWriteLongTestCases")
+    void writeLongBits(final long[] writes, final byte[] expectedBytes) throws IOException {
+        final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (final BitOutputStream output = BitOutputStream.forOutput(bytes)) {
+            for (int i = 0; i < writes.length / 2; i++) {
+                output.write(writes[i * 2 + 0], (int) writes[i * 2 + 1]);
+            }
+        }
+        assertThat(bytes.toByteArray()).isEqualTo(expectedBytes);
+    }
+
+    static Stream<Arguments> generateWriteLongTestCases() {
+        final Map<long[], byte[]> testCases = new LinkedHashMap<>();
+        // 1
+        testCases.put(writes(new long[0]), expected());
+        testCases.put(writes(0b00000000L, 0), expected());
+        testCases.put(writes(0b11111111L, 0), expected());
+        testCases.put(writes(0b00000000L, 1), expected(0b00000000));
+        // 5
+        testCases.put(writes(0b00000001L, 1), expected(0b10000000));
+        testCases.put(writes(0b00000011L, 4), expected(0b00110000));
+        testCases.put(writes(0b10000011L, 8), expected(0b10000011));
+        testCases.put(writes(0b00000001L, 1, 0b00000010, 3), expected(0b10100000));
+        testCases.put(writes(0b00000001L, 1, 0b00000010, 3, 0b00000011, 4), expected(0b10100011));
+        // 10
+        testCases.put(writes(0b10101010L, 8, 0b00000001, 1), expected(0b10101010, 0b10000000));
+        testCases.put(writes(0b11110000L, 8, 0b00001111, 8), expected(0b11110000, 0b00001111));
+        testCases.put(writes(0b11110000L, 8, 0b00001111, 8, 0b00001111, 4), expected(0b11110000, 0b00001111, 0b11110000));
+
+        testCases.put(writes(0b00000001L, 1), expected(0b10000000));
+        testCases.put(writes(0b00000001L, 1, 0b00000001, 1), expected(0b11000000));
+        // 15
+        testCases.put(writes(0b00000001L, 1, 0b00000001, 1, 0b00000001, 1), expected(0b11100000));
+        testCases.put(writes(0b00000001L, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1), expected(0b11110000));
+        testCases.put(writes(0b00000001L, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1), expected(0b11111000));
+        testCases.put(writes(0b00000001L, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1), expected(0b11111100));
+        testCases.put(writes(0b00000001L, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1), expected(0b11111110));
+        // 20
+        testCases.put(writes(0b00000001L, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1), expected(0b11111111));
+        testCases.put(writes(0b00000001L, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1), expected(0b11111111, 0b10000000));
+        testCases.put(writes(0b00000001L, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1, 0b00000001, 1), expected(0b11111111, 0b11000000));
+
+        testCases.put(writes(0x02345678L, 31), expected(0x04, 0x68, 0xac, 0xf0));
+        testCases.put(writes(0x12345678L, 32), expected(0x12, 0x34, 0x56, 0x78));
+        // 25
+        testCases.put(writes(0x1234567812345678L, 64), expected(0x12, 0x34, 0x56, 0x78, 0x12, 0x34, 0x56, 0x78));
+
+        return testCases.entrySet().stream()
+            .map(entry -> {
+                final long[] writes = entry.getKey();
+                final byte[] expected = entry.getValue();
+
+                final String[] writesDisplay = new String[writes.length / 2];
+                for (int i = 0; i < writes.length / 2; i++) {
+                    writesDisplay[i] = "<" + longToBinaryString(writes[i * 2 + 0]).substring((int) (64 - writes[i * 2 + 1]), 64) + ">";
+                }
+                final String[] expectedDisplay = new String[expected.length];
+                for (int i = 0; i < expected.length; i++) {
+                    expectedDisplay[i] = byteToBinaryString(expected[i] & 0xff);
+                }
+
+                return argumentSet(
+                    String.join(" ", writesDisplay) + " => " + String.join(" ", expectedDisplay),
+                    writes,
+                    expected
+                );
+            });
+    }
+
+    private static int[] writes(final int... writes) {
+        return writes;
+    }
+
+    private static long[] writes(final long... writes) {
+        return writes;
+    }
+
+    private static byte[] expected(final int... bytes) {
+        final byte[] converted = new byte[bytes.length];
+        for (int i = 0; i < bytes.length; i++) {
+            converted[i] = (byte) bytes[i];
+        }
+        return converted;
+    }
+
+    public static String byteToBinaryString(final int uByte) {
+        return String.format("%8s", Integer.toBinaryString(uByte & 0xff)).replaceAll(" ", "0");
+    }
+
+    public static String longToBinaryString(final long bits) {
+        return String.format("%64s", Long.toBinaryString(bits)).replaceAll(" ", "0");
+    }
+}

--- a/src/test/java/nl/nfi/djpcfg/guess/cache/distributed/CheckpointCacheClientTest.java
+++ b/src/test/java/nl/nfi/djpcfg/guess/cache/distributed/CheckpointCacheClientTest.java
@@ -1,0 +1,57 @@
+package nl.nfi.djpcfg.guess.cache.distributed;
+
+import nl.nfi.djpcfg.guess.cache.Checkpoint;
+import nl.nfi.djpcfg.guess.pcfg.ParseTree;
+import nl.nfi.djpcfg.guess.pcfg.Pcfg;
+import nl.nfi.djpcfg.guess.pcfg.ReplacementSet;
+import nl.nfi.djpcfg.serialize.PcfgCodec;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Random;
+
+import static java.util.Comparator.comparing;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CheckpointCacheClientTest {
+
+    private static final int RANDOM_PORT = 63535;
+
+    private static final Path TEST_RESOURCES_PATH = Paths.get("src/test/resources").toAbsolutePath();
+
+    private static final Path DEFAULT_RULE_PATH = TEST_RESOURCES_PATH.resolve("rules/Default.pbm");
+
+    @TempDir
+    Path tempWorkDir;
+
+    @Test
+    void writeByteArrayLargerThanMaxMessageSize() throws IOException {
+        final Pcfg pcfg = PcfgCodec.forInput(DEFAULT_RULE_PATH).read();
+
+        try (final CheckpointCacheServer server = CheckpointCacheServer.start(RANDOM_PORT, tempWorkDir);
+             final CheckpointCacheClient client = CheckpointCacheClient.connect("localhost", RANDOM_PORT)) {
+
+            final Random random = new Random(0);
+            final PriorityQueue<ParseTree> queue = new PriorityQueue<>(comparing(ParseTree::probability).reversed());
+            for (int i = 0; i < 20000000; i++) {
+                final List<String> variables = pcfg.baseStructures().get(0).variables();
+                queue.add(new ParseTree(
+                    1.0,
+                    // generate a lot of random doubles, should compress less good
+                    random.nextDouble(),
+                    new ReplacementSet(variables, new int[variables.size()]))
+                );
+            }
+
+            final Checkpoint checkpoint = new Checkpoint(queue, queue.poll(), 42);
+
+            final boolean didStore = client.store(pcfg, pcfg.ruleInfo().uuid(), checkpoint.keyspacePosition(), checkpoint);
+            assertThat(didStore).isTrue();
+        }
+    }
+}

--- a/src/test/java/nl/nfi/djpcfg/serialize/CheckpointCodecTest.java
+++ b/src/test/java/nl/nfi/djpcfg/serialize/CheckpointCodecTest.java
@@ -1,0 +1,104 @@
+package nl.nfi.djpcfg.serialize;
+
+import nl.nfi.djpcfg.common.Timers;
+import nl.nfi.djpcfg.common.Timers.TimedResult;
+import nl.nfi.djpcfg.guess.cache.Checkpoint;
+import nl.nfi.djpcfg.guess.cache.CheckpointCache;
+import nl.nfi.djpcfg.guess.cache.directory.DirectoryCheckpointCache;
+import nl.nfi.djpcfg.guess.pcfg.Pcfg;
+import nl.nfi.djpcfg.guess.pcfg.PcfgGuesser;
+import nl.nfi.djpcfg.guess.pcfg.generate.Mode;
+import nl.nfi.djpcfg.serialize.common.JreTypeCodec;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+
+import static java.io.OutputStream.nullOutputStream;
+import static nl.nfi.djpcfg.common.Formatting.toHumanReadableSize;
+import static nl.nfi.djpcfg.common.Timers.time;
+
+class CheckpointCodecTest {
+
+    // 100 000 000 000 / 100 000
+
+//    @Disabled
+    @Test
+    void size() throws IOException {
+        final Path rulePath = Paths.get("src/test/resources/rules/Default.pbm");
+         final Path inputPath = Paths.get("src/test/resources/checkpoints/384adebf-ba38-4307-891d-5b4a0a02178b_999998816");
+
+        final ByteArrayOutputStream v0_0_7 = new ByteArrayOutputStream();
+        final ByteArrayOutputStream v0_4_0 = new ByteArrayOutputStream();
+
+        try (final PcfgCodec.Decoder pcfgDecoder = PcfgCodec.forInput(rulePath)) {
+            final Pcfg pcfg = pcfgDecoder.read();
+
+            final Checkpoint checkpoint;
+
+            final JreTypeCodec.Decoder decoderBase = JreTypeCodec.forInput(inputPath);
+            decoderBase.readString(); // magic
+            decoderBase.readString(); // version
+
+            try (final nl.nfi.djpcfg.serialize.v0_0_7.CheckpointCodec.Decoder decoder = nl.nfi.djpcfg.serialize.v0_0_7.CheckpointCodec.Decoder.decodeUsing(decoderBase)) {
+                final TimedResult<Checkpoint> oldRead = time(() -> decoder.readCheckpointUsingBaseRefs(pcfg));
+                System.out.println(" Read checkpoint 0.0.7: " + oldRead.duration());
+                checkpoint = oldRead.value();
+            }
+            try (final nl.nfi.djpcfg.serialize.v0_0_7.CheckpointCodec.Encoder encoder = nl.nfi.djpcfg.serialize.v0_0_7.CheckpointCodec.Encoder.encodeUsing(JreTypeCodec.forOutput(v0_0_7))) {
+                final Duration oldWrite = time(() -> encoder.writeCheckpointUsingBaseRefs(pcfg, checkpoint));
+                System.out.println("Write checkpoint 0.0.7: " + oldWrite);
+            }
+
+            try (final nl.nfi.djpcfg.serialize.v0_4_0.CheckpointCodec.Encoder encoder = nl.nfi.djpcfg.serialize.v0_4_0.CheckpointCodec.encodeUsing(JreTypeCodec.forOutput(v0_4_0))) {
+                final Duration newWrite = time(() -> encoder.writeCheckpointUsingBaseRefs(pcfg, checkpoint));
+                System.out.println("Write checkpoint 0.4.0: " + newWrite);
+            }
+            try (final nl.nfi.djpcfg.serialize.v0_4_0.CheckpointCodec.Decoder encoder = nl.nfi.djpcfg.serialize.v0_4_0.CheckpointCodec.decodeUsing(JreTypeCodec.forInput(new ByteArrayInputStream(v0_4_0.toByteArray())))) {
+                final TimedResult<Checkpoint> newRead = time(() -> encoder.readCheckpointUsingBaseRefs(pcfg));
+                final Checkpoint checkpoint_v0_4_0 = newRead.value();
+                System.out.println(" Read checkpoint 0.4.0: " + newRead.duration());
+                // System.out.println("Checkpoint remains unchanged: " + checkpoint.equals(checkpoint_v0_4_0));
+            }
+            System.out.println(toHumanReadableSize(v0_0_7.size()));
+            System.out.println(toHumanReadableSize(v0_4_0.size()));
+            System.out.println("Average of %.2f bytes per entry in the queue".formatted(v0_4_0.size() * 1.0d / checkpoint.queue().size()));
+
+        }
+
+        // Read checkpoint 0.0.7: PT9.76188727S
+        //Write checkpoint 0.0.7: PT7.148435045S
+        //Compressed 233798061 indices from 891.9MiB to 107.6MiB
+        //Write checkpoint 0.4.0: PT28.712268997S
+        // Read checkpoint 0.4.0: PT11.188733109S
+        //true
+        //541.1MiB
+        //196.3MiB
+        //Average of 6.81 bytes per entry in the queue
+    }
+
+    @Disabled
+    @Test
+    void generateIt() throws IOException {
+        final Path rulePath = Paths.get("src/test/resources/rules/Default.pbm");
+
+        System.setProperty("LOG_DIRECTORY_PATH", "logs");
+
+        final CheckpointCache cache = DirectoryCheckpointCache.createOrLoadFrom(Paths.get("directory"));
+        final PcfgGuesser guesser = PcfgGuesser.forRule(rulePath)
+                .mode(Mode.TRUE_PROB_ORDER)
+                .threadCount(4)
+                .cache(cache);
+
+        for (int i = 0; i < 32; i++) {
+            guesser.generateGuesses(i * 1000000000L, 1, new PrintStream(nullOutputStream()));
+            System.out.println(i);
+        }
+    }
+}


### PR DESCRIPTION
POC for #1 

Possible TODO's:

- [ ] (de)serialize from worst to best probability, such that when queue memory management triggers, the worst entries are removed first
- [ ] cleanup code
- [ ] reduce memory footprint of compression state
- [ ] check other possible compression libraries
- [ ] ...